### PR TITLE
Add support for custom measures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Options with `none` as the default are required.
 | `--qrels` | `string` | `none` | `--qrels $(pwd)/qrels/qrels.robust2004.txt` | the qrels file for evaluation
 | `--opts` | `[key]=[value] ...` | `none` | `--opts search_args="-bm25"` | extra options passed to the search script
 | `--timings` | `flag` | `false` | `--timings` | print timing info (requires the `time` package, or `bash`, to be installed in Dockerfile)
+| `--measures` | `string ...` | `"map P.30"` | `--measures recall.1000 map` | the measures for trec_eval
 
 ### Command Line Options - train
 

--- a/run.py
+++ b/run.py
@@ -69,6 +69,7 @@ if __name__ == "__main__":
                                help="the subset of topic ids to use for testing")
     parser_search.add_argument("--opts", nargs="+", default="", type=str, help="the args passed to the search script")
     parser_search.add_argument("--timings", action="store_true", help="enable timing information to be printed")
+    parser_search.add_argument("--measures", nargs="+", default=["map", "P.30"], type=str, help="the measures for trec_eval")
 
     # Specific to interact
     parser_interact = parser_sub.add_parser("interact")

--- a/searcher.py
+++ b/searcher.py
@@ -124,9 +124,12 @@ class Searcher:
             print('sys {:.2f}'.format(result[2]))
             print()
 
+        # The measure string passed to trec_eval
+        measures = " ".join(map(lambda x: "-m {}".format(x), self.config.measures))
+
         print("Evaluating results using trec_eval...")
         for file in os.listdir(self.config.output):
             run = os.path.join(self.config.output, file)
             print("###\n# {}\n###".format(run))
-            subprocess.run(["trec_eval/trec_eval", "-m", "map", "-m", "P.30", self.config.qrels, run])
+            subprocess.run("trec_eval/trec_eval {} {} {}".format(measures, self.config.qrels, run).split())
             print()


### PR DESCRIPTION
Should fix https://github.com/osirrc/jig/issues/97 by passing `--measures "ndcg"` (or some of the other ndcg measures, see below) during `search`.

```
$ python run.py search --repo osirrc2019/anserini --topic topics/topics.robust04.txt --qrels qrels/qrels.robust04.txt --collection robust04 --output out/anserini --opts search_args="-bm25" out_file_name="bm25.run" --measures "ndcg"
Starting container from saved image...
Logs for search in container with ID c8e2f34875b3125a00016aa67fe99a17da0faf7d00a056993fa6914d1c82a4cc...
2019-06-07 23:11:07,560 INFO  [main] search.SearchCollection (SearchCollection.java:183) - Reading index at robust04
2019-06-07 23:11:08,270 INFO  [main] search.SearchCollection (SearchCollection.java:203) - Use Bag of Terms query
2019-06-07 23:11:08,301 INFO  [pool-2-thread-1] search.SearchCollection$SearcherThread (SearchCollection.java:134) - [Start] Ranking with similarity: BM25(k1=0.9,b=0.4)
2019-06-07 23:11:22,152 INFO  [pool-2-thread-1] search.SearchCollection$SearcherThread (SearchCollection.java:166) - [Finished] Ranking with similarity: BM25(k1=0.9,b=0.4)
2019-06-07 23:11:22,157 INFO  [pool-2-thread-1] search.SearchCollection$SearcherThread (SearchCollection.java:167) - Run 250 topics searched in 00:00:13
2019-06-07 23:11:22,209 INFO  [main] search.SearchCollection (SearchCollection.java:499) - Total run time: 00:00:14
Evaluating results using trec_eval...
###
# out/anserini/bm25.run
###
ndcg                    all     0.5265
```