### PR TITLE
Information on the number of queries processed by trec_eval as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Options with `none` as the default are required.
 | `--qrels` | `string` | `none` | `--qrels $(pwd)/qrels/qrels.robust2004.txt` | the qrels file for evaluation
 | `--opts` | `[key]=[value] ...` | `none` | `--opts search_args="-bm25"` | extra options passed to the search script
 | `--timings` | `flag` | `false` | `--timings` | print timing info (requires the `time` package, or `bash`, to be installed in Dockerfile)
-| `--measures` | `string ...` | `"map P.30"` | `--measures recall.1000 map` | the measures for trec_eval
+| `--measures` | `string ...` | `"num_q map P.30"` | `--measures recall.1000 map` | the measures for trec_eval
 
 ### Command Line Options - train
 

--- a/run.py
+++ b/run.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
                                help="the subset of topic ids to use for testing")
     parser_search.add_argument("--opts", nargs="+", default="", type=str, help="the args passed to the search script")
     parser_search.add_argument("--timings", action="store_true", help="enable timing information to be printed")
-    parser_search.add_argument("--measures", nargs="+", default=["map", "P.30"], type=str, help="the measures for trec_eval")
+    parser_search.add_argument("--measures", nargs="+", default=["num_q", "map", "P.30"], type=str, help="the measures for trec_eval")
 
     # Specific to interact
     parser_interact = parser_sub.add_parser("interact")


### PR DESCRIPTION
Indri for instance fails rather silently - if for some reason a query isn't processed, there is an exception written to the result file and that's it. The same goes for trec_eval - it simply computes what it can based on the valid result lines. As a sanity check, printing out the number of queries trec_eval has processed would help.